### PR TITLE
config file: Show documents

### DIFF
--- a/data/grilo-system.conf
+++ b/data/grilo-system.conf
@@ -1,6 +1,7 @@
 [grl-tracker]
 per-device-source = true
 browse-filesystem = true
+show-documents = true
 
 [grl-vimeo]
 api-key = YOUR_API_KEY_HERE


### PR DESCRIPTION
New option added in Grilo 0.1.18.

By default, in Grilo 0.1.18 tracker won't expose the documents, unless the "show-documents" option is passed.

This patch activates this option.
