### PR TITLE
build: detect tracker-sparql-0.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,9 +427,12 @@ AC_ARG_ENABLE([webremote],
               [],
               [enable_webremote=yes])
 
-PKG_CHECK_EXISTS([tracker-sparql-0.12],
-                 [tracker_dep="tracker-sparql-0.12"],
-                 [tracker_dep="tracker-sparql-0.10"])
+PKG_CHECK_EXISTS([tracker-sparql-0.14],
+		 [tracker_dep="tracker-sparql-0.14"],
+		 [PKG_CHECK_EXISTS([tracker-sparql-0.12],
+			[tracker_dep="tracker-sparql-0.12"],
+			[tracker_dep="tracker-sparql-0.10"])
+		 ])
 
 AS_IF([test "x$enable_webremote" = "xyes"],
       [PKG_CHECK_MODULES(WEBREMOTE, [glib-2.0 json-glib-1.0 gio-2.0 libsoup-2.4 $tracker_dep avahi-glib avahi-client])


### PR DESCRIPTION
Tracker changes the .pc file not only when the API changes but actually with every version (versioned .pc files).

As such, currently, tracker-sparql-0.14 is not detected by configure. Simply adding the detection seems to be sufficient to support tracker 0.14 (tested with tracker 0.13.0
