### PR TITLE
Port telepathy mex plugin to gstreamer 1.0

### DIFF
--- a/README
+++ b/README
@@ -56,7 +56,7 @@ The core of Media Explorer depends on:
   • clutter-gst-1.0 ≥ 1.4.0
   • rest-0.7
   • grilo-0.2
-  • gstreamer-0.10 ≥ 0.10.26
+  • gstreamer-1.0
   • LIRC (optional but recommended)
 
 The webremote applet (used by the android application) is enabled by default

--- a/build/Makefile.am.release
+++ b/build/Makefile.am.release
@@ -76,7 +76,7 @@ release-message: $(sha256_file)
 	@echo "  • clutter-gst-1.0 ≥ $(CLUTTER_GST_REQ_VERSION)"
 	@echo "  • rest-0.7"
 	@echo "  • grilo-0.2"
-	@echo "  • gstreamer-0.10 ≥ $(GSTREAMER_REQ_VERSION)"
+	@echo "  • gstreamer-1.0 ≥ $(GSTREAMER_REQ_VERSION)"
 	@echo "  • LIRC (optional but recommended)"
 	@echo ""
 	@echo "The webremote applet (used by the android application) is enabled by default"

--- a/configure.ac
+++ b/configure.ac
@@ -476,9 +476,9 @@ AS_MEX_PLUGIN(bliptv)
 AS_MEX_PLUGIN(justintv)
 AS_MEX_PLUGIN(telepathy,
               [telepathy-glib >= $TELEPATHY_GLIB_REQ_VERSION  \
-               gstreamer-0.10                                 \
+               gstreamer-1.0                                  \
                telepathy-farstream                            \
-               farstream-0.1])
+               farstream-0.2])
 AS_MEX_PLUGIN(debug-buddy)
 AS_MEX_PLUGIN(gnome-dvb)
 AS_MEX_PLUGIN(opticaldisc)

--- a/mex/Makefile.am
+++ b/mex/Makefile.am
@@ -272,6 +272,7 @@ libmex_@MEX_API_VERSION@_la_LIBADD =					\
 	$(MEX_LIBS)							\
 	$(TRACKER_LIBS)							\
 	$(NM_LIBS)							\
+    -lm \
 	$(NULL)
 
 libmex_@MEX_API_VERSION@_la_LDFLAGS = -no-undefined


### PR DESCRIPTION
Tested locally and it exposes a bug in gstreamer-plugins-good v4l2.
Tested with workaround for that bug and it works fine.
Bug hit is https://bugzilla.gnome.org/show_bug.cgi?id=697236
